### PR TITLE
StringifyBytesConverter - converts byte arrays or multi-byte numbers to numeric representations such as binary, hexidecimal, or octal

### DIFF
--- a/ccsdspy/converters.py
+++ b/ccsdspy/converters.py
@@ -348,11 +348,12 @@ class StringifyBytesConverter(Converter):
         converted : NumPy array
             converted form of the converted packet field values
         """
-        # field_arrays may either be a 1-D array or an N-D array where N>1.
-        # These are implemented separately.
+        # field_arrays may either be a 1-D array, or an N-D array where N>1
+        # (this includes jagged arrays where the outer array is of
+        # dtype=object). These are implemented separately.
         ndims = len(field_array.shape)
 
-        if ndims == 1:
+        if ndims == 1 and field_array.dtype != object:
             converted = []
 
             for num in field_array:
@@ -364,6 +365,7 @@ class StringifyBytesConverter(Converter):
             for i in range(field_array.shape[0]):
                 cur_array_flat = field_array[i].flatten()
                 n_items = cur_array_flat.shape[0]
+                cur_shape = field_array[i].shape
 
                 # Loop over elements, converting individually
                 curr_array_strings = []
@@ -373,9 +375,7 @@ class StringifyBytesConverter(Converter):
                     curr_array_strings.append(as_string)
 
                 # Put back into original array shape
-                curr_array_strings = np.array(curr_array_strings, dtype=object).reshape(
-                    field_array.shape[1:]
-                )
+                curr_array_strings = np.array(curr_array_strings, dtype=object).reshape(cur_shape)
                 converted.append(curr_array_strings)
 
         converted = np.array(converted, dtype=object)

--- a/ccsdspy/converters.py
+++ b/ccsdspy/converters.py
@@ -279,3 +279,97 @@ class DatetimeConverter(Converter):
         converted = np.array(converted, dtype=object)
 
         return converted
+
+
+class StringifyBytesConverter(Converter):
+    """Post-processing conversion which converts an array of bytes to string
+    representations using an encoding such as binary, hexidecimal, or octal.
+
+    If the field is an array, the shape of the array is retained.
+
+    The converted strings contain prefixes such as "0b" (binary), "0x" (hex), or
+    "0o" (octal). They are not padded to be a fixed length.
+    """
+
+    def __init__(self, format="hex"):
+        """Instantiate a StringifyBytesConverter object
+
+        Parameters
+        ----------
+        format : {"bin", "hex", "oct"}
+           Format used to encode the bytes in a string.
+        """
+        if format not in ("bin", "hex", "oct"):
+            raise ValueError(
+                "The format= keyword passed to StringifyBytesConverter "
+                f"must be either 'bin', 'hex', or 'oct'. Got {repr(format)}"
+            )
+
+        self._format = format
+
+    def _stringify_number(self, num, nbytes):
+        """Internal helper method to convert a number to a string.
+
+        Parameters
+        ----------
+        number : int
+           A single number to convert to string
+
+        Returns
+        --------
+        as_string : the byte converted to a string using the format
+           specified when this object was created.
+        """
+        if self._format == "bin":
+            return bin(num)
+        elif self._format == "hex":
+            return hex(num)
+        else:
+            return oct(num)
+
+    def convert(self, field_array):
+        """Apply the bytes to string conversion.
+
+        Parameters
+        ----------
+        field_array : NumPy array
+            decoded packet field values, must have at least two dimensions
+
+        Returns
+        -------
+        converted : NumPy array
+            converted form of the converted packet field values
+        """
+        # field_arrays may either be a 1-D array or an N-D array where N>1.
+        # These are implemented separately.
+        ndims = len(field_array.shape)
+
+        if ndims == 1:
+            converted = []
+
+            for num in field_array:
+                as_string = self._stringify_number(num, field_array.itemsize)
+                converted.append(as_string)
+        else:
+            converted = []
+
+            for i in range(field_array.shape[0]):
+                cur_array_flat = field_array[i].flatten()
+                n_items = cur_array_flat.shape[0]
+
+                # Loop over elements, converting individually
+                curr_array_strings = []
+
+                for element in cur_array_flat:
+                    as_string = self._stringify_number(element, cur_array_flat.itemsize)
+                    curr_array_strings.append(as_string)
+
+                # Put back into original array shape
+                curr_array_strings = np.array(curr_array_strings, dtype=object).reshape(
+                    field_array.shape[1:]
+                )
+                converted.append(curr_array_strings)
+
+        converted = np.array(converted, dtype=object)
+
+        return converted

--- a/ccsdspy/converters.py
+++ b/ccsdspy/converters.py
@@ -14,6 +14,7 @@ __all__ = [
     "LinearConverter",
     "EnumConverter",
     "DatetimeConverter",
+    "StringifyBytesConverter",
 ]
 
 
@@ -282,13 +283,20 @@ class DatetimeConverter(Converter):
 
 
 class StringifyBytesConverter(Converter):
-    """Post-processing conversion which converts an array of bytes to string
-    representations using an encoding such as binary, hexidecimal, or octal.
+    """Post-processing conversion which converts byte arrays or multi-byte
+    numbers to strings in numeric representations such as binary, hexidecimal,
+    or octal.
 
-    If the field is an array, the shape of the array is retained.
+    To convert individual bytes, the input field should be defined as a
+    `~ccsdspy.PacketArray` constructed with `data_type="uint"` and
+    `bit_length=8`. Otherwise, each element is converted as a single entity.
 
-    The converted strings contain prefixes such as "0b" (binary), "0x" (hex), or
-    "0o" (octal). They are not padded to be a fixed length.
+    If the field is an array, the shape of the array is retained. The strings
+    generated are not padded to a fixed length.
+
+    The converted strings contain prefixes such as `0b` (binary), `0x` (hex),
+    or `0o` (octal). If the number is signed and negative, the prefixes change
+    to `-0b` (binary), `-0x` (hex), or `-0o` (octal).
     """
 
     def __init__(self, format="hex"):
@@ -328,7 +336,7 @@ class StringifyBytesConverter(Converter):
             return oct(num)
 
     def convert(self, field_array):
-        """Apply the bytes to string conversion.
+        """Apply the conversion.
 
         Parameters
         ----------

--- a/ccsdspy/tests/test_converters.py
+++ b/ccsdspy/tests/test_converters.py
@@ -305,6 +305,122 @@ def test_stringify_bytes_converter_1d_uint8(format):
 
 
 @pytest.mark.parametrize("format", ["bin", "oct", "hex"])
+def test_stringify_bytes_converter_2d_jagged_uint8(format):
+    field_array = np.array(
+        [
+            np.array([0, 10, 20], dtype=np.uint8),
+            np.array([], dtype=np.uint8),
+            np.array([30], dtype=np.uint8),
+            np.array([40, 50], dtype=np.uint8),
+        ],
+        dtype=object,
+    )
+
+    converter = converters.StringifyBytesConverter(format=format)
+    result = converter.convert(field_array)
+
+    assert isinstance(result, np.ndarray)
+    assert np.issubdtype(result.dtype, object)
+
+    if format == "bin":
+        expected = np.array(
+            [
+                np.array(
+                    [
+                        "0b0",  #   0
+                        "0b1010",  #  10
+                        "0b10100",  #  20
+                    ],
+                    dtype=object,
+                ),
+                np.array([], dtype=object),
+                np.array(
+                    [
+                        "0b11110",  #  30
+                    ],
+                    dtype=object,
+                ),
+                np.array(
+                    [
+                        "0b101000",  #  40
+                        "0b110010",  #  50
+                    ],
+                    dtype=object,
+                ),
+            ],
+            dtype=object,
+        )
+    elif format == "hex":
+        expected = np.array(
+            [
+                np.array(
+                    [
+                        "0x0",  #   0
+                        "0xa",  #  10
+                        "0x14",  #  20
+                    ],
+                    dtype=object,
+                ),
+                np.array([], dtype=object),
+                np.array(
+                    [
+                        "0x1e",  #  30
+                    ],
+                    dtype=object,
+                ),
+                np.array(
+                    [
+                        "0x28",  #  40
+                        "0x32",  #  50
+                    ],
+                    dtype=object,
+                ),
+            ],
+            dtype=object,
+        )
+
+    elif format == "oct":
+        expected = np.array(
+            [
+                np.array(
+                    [
+                        "0o0",  #   0
+                        "0o12",  #  10
+                        "0o24",  #  20
+                    ],
+                    dtype=object,
+                ),
+                np.array([], dtype=object),
+                np.array(
+                    [
+                        "0o36",  #  30
+                    ],
+                    dtype=object,
+                ),
+                np.array(
+                    [
+                        "0o50",  #  40
+                        "0o62",  #  50
+                    ],
+                    dtype=object,
+                ),
+            ],
+            dtype=object,
+        )
+    else:
+        raise RuntimeError("Invalid format")
+
+    assert expected.shape == result.shape
+
+    for i in range(expected.shape[0]):
+        assert np.issubdtype(result[i].dtype, object)
+        assert_array_equal(
+            result[i],
+            expected[i],
+        )
+
+
+@pytest.mark.parametrize("format", ["bin", "oct", "hex"])
 def test_stringify_bytes_converter_2d_uint16(format):
     field_array = np.arange(230, 290, 10, dtype=">u2").reshape((2, 3))
     converter = converters.StringifyBytesConverter(format=format)
@@ -369,6 +485,40 @@ def test_stringify_bytes_converter_2d_uint16(format):
                 ],
                 dtype=object,
             ),
+        )
+
+
+@pytest.mark.parametrize("format", ["bin", "oct", "hex"])
+def test_stringify_bytes_converter_1d_uint16(format):
+    field_array = np.arange(230, 290, 10, dtype=">u2")
+    converter = converters.StringifyBytesConverter(format=format)
+    result = converter.convert(field_array)
+
+    assert isinstance(result, np.ndarray)
+    assert np.issubdtype(result.dtype, object)
+
+    if format == "bin":
+        assert_array_equal(
+            result,
+            np.array(
+                [
+                    "0b11100110",
+                    "0b11110000",
+                    "0b11111010",
+                    "0b100000100",
+                    "0b100001110",
+                    "0b100011000",
+                ],
+                dtype=object,
+            ),
+        )
+    elif format == "hex":
+        assert_array_equal(
+            result, np.array(["0xe6", "0xf0", "0xfa", "0x104", "0x10e", "0x118"], dtype=object)
+        )
+    elif format == "oct":
+        assert_array_equal(
+            result, np.array(["0o346", "0o360", "0o372", "0o404", "0o416", "0o430"], dtype=object)
         )
 
 

--- a/docs/user-guide/converters.rst
+++ b/docs/user-guide/converters.rst
@@ -4,8 +4,6 @@
 Post-Processing Transformations
 ********************************
 
-
-
 Post-processing transformations are done through the Converters API, exposed through the `~ccsdspy.converters` module. Using Converters, one can create new fields transformed from another field. Examples including applying calibration curves, replacing enumerated values with strings, or converting your own time definition to a `datetime` instance. The following converters are built in, and you can write your own converter by extending the `~ccsdspy.converters.Converter` class (more on this below). When new fields are transformed from other fields, they are created as new entries in the returned dictionary.
 
 #. Polynomial Transformation (`~ccsdspy.converters.PolyConverter`)
@@ -24,6 +22,10 @@ Post-processing transformations are done through the Converters API, exposed thr
 
    This converts fields to datetime instances, computed using offset(s) from a reference time. The offsets can span multiple fields (for example, one a coarse time, and another for a fine time). If the reference time has a timezone, the result will too.
 
+#. Stringify Bytes Transformation (`~ccsdspy.converters.StringifyBytesConverter`)
+
+   This converts byte arrays or multi-byte numbers to strings in numeric representations such as binary, hexidecimal, or octal.
+   
 .. contents::
    :depth: 2
 


### PR DESCRIPTION
This implements the change requested in #73.

A new converter class is added, called `ccsdspy.converters.StringifyBytesConverter`, which will convert an array to number representations such as binary, hexidecimal, or octal. The full docstring of the class is quoted below:

```python
class StringifyBytesConverter(Converter):
    """Post-processing conversion which converts byte arrays or multi-byte 
    numbers to strings in numeric representations such as binary, hexidecimal, 
    or octal. 

    To convert individual bytes, the input field should be defined as a
    `~ccsdspy.PacketArray` constructed with `data_type="uint"` and 
    `bit_length=8`. Otherwise, each element is converted as a single entity.

    If the field is an array, the shape of the array is retained. The strings
    generated are not padded to a fixed length.

    The converted strings contain prefixes such as `0b` (binary), `0x` (hex),
    or `0o` (octal). If the number is signed and negative, the prefixes change
    to `-0b` (binary), `-0x` (hex), or `-0o` (octal).
    """
    def __init__(self, format="hex"):

```

An example of the usage follows.

```python

from ccsdspy import VariableLength, PacketArray
from ccsdspy.converters import StringifyBytesConverter

pkt = VariableLength([
    PacketField(name="MyField",  data_type="uint", bit_length=8),
])

pkt.add_converted_field(
    "MyField"
    "MyField_Binary",
     StringifyBytesConverter(format="binary")
)
result = pkt.load("MyCCSDS.bin")
print(result['MyField_Binary'])

# prints the following array, when the actual data is populated with np.arange(0, 60, 10, dtype=np.uint8)
np.array([
    "0b0",  
    "0b1010",  
    "0b10100",  
    "0b11110", 
    "0b101000",  
    "0b110010",
 ], dtype=object)