### PR TITLE
Spelling and missing paren

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Version 0.0.13 - 2023-01-03
   * Added the ability to parse variable length files
   * Added the ability to specify packet field that are arrays
   * Added the ability to define a packet through a csv file
-  * Added github actions to perform continuous intergration
+  * Added github actions to perform continuous integration
   * Specified black as the only accepted code formatter
 
 Version 0.0.12 - 2022-08-06

--- a/ccsdspy/converters.py
+++ b/ccsdspy/converters.py
@@ -163,7 +163,7 @@ class EnumConverter(Converter):
 
             raise EnumConverterMissingKey(
                 f"The following were encountered which did not have "
-                f"corresponding keys in the replacment dictionary: "
+                f"corresponding keys in the replacement dictionary: "
                 f"{repr(missing_keys)}"
             )
 
@@ -175,8 +175,8 @@ class DatetimeConverter(Converter):
     instances, computed using offset(s) from a reference time.
 
     This class supports the offsets stored in multiple input fields, for example
-    where one field is a coarse time (eg seconds) and a second field is a fine
-    time (eg nanoseconds). To use multiple input fields, pass a tuple of input
+    where one field is a coarse time (e.g. seconds) and a second field is a fine
+    time (e.g. nanoseconds). To use multiple input fields, pass a tuple of input
     field names when this converter is added to the packet.
     """
 
@@ -284,7 +284,7 @@ class DatetimeConverter(Converter):
 
 class StringifyBytesConverter(Converter):
     """Post-processing conversion which converts byte arrays or multi-byte
-    numbers to strings in numeric representations such as binary, hexidecimal,
+    numbers to strings in numeric representations such as binary, hexadecimal,
     or octal.
 
     To convert individual bytes, the input field should be defined as a

--- a/ccsdspy/decode.py
+++ b/ccsdspy/decode.py
@@ -275,7 +275,7 @@ def _decode_variable_length(file_bytes, fields):
     dict
     A dictionary mapping field names to NumPy arrays, stored in the same order as the fields.
     """
-    # Get start indeces of each packet -------------------------------------
+    # Get start indices of each packet -------------------------------------
     packet_starts = []
     offset = 0
 

--- a/ccsdspy/packet_fields.py
+++ b/ccsdspy/packet_fields.py
@@ -82,7 +82,7 @@ class PacketField:
             return (
                 "{cls_name}(name={_name}, data_type={_data_type}, "
                 "bit_length={_bit_length}, bit_offset={_bit_offset}, "
-                "byte_order={_byte_order}".format(**values)
+                "byte_order={_byte_order})".format(**values)
             )
 
     def __iter__(self):

--- a/ccsdspy/packet_types.py
+++ b/ccsdspy/packet_types.py
@@ -41,7 +41,7 @@ class _BasePacket:
         ----------
         file : str
            Path to file on the local file system that defines the packet fields.
-           Currently only suports csv files.
+           Currently only supports csv files.
            See :download:`simple_csv_3col.csv <../../ccsdspy/tests/data/packet_def/simple_csv_3col.csv>`  # noqa: E501
            and :download:`simple_csv_4col.csv <../../ccsdspy/tests/data/packet_def/simple_csv_4col.csv>`  # noqa: E501
 
@@ -58,8 +58,8 @@ class _BasePacket:
         return cls(fields)
 
     def add_converted_field(self, input_field_name, output_field_name, converter):
-        """Add a converteed field to the packet definition, used to apply
-        post-processing transformatons of decoded fields.
+        """Add a converted field to the packet definition, used to apply
+        post-processing transformations of decoded fields.
 
         Parameters
         ----------
@@ -116,7 +116,7 @@ class _BasePacket:
 class FixedLength(_BasePacket):
     """Define a fixed length packet to decode binary data.
 
-    Fixed length packets correspond to packats that are the same length and
+    Fixed length packets correspond to packets that are the same length and
     layout every time. A common example of this is housekeeping or status
     messages.
     """
@@ -378,7 +378,7 @@ def _expand_array_fields(existing_fields):
 
         index_vecs = [np.arange(dim) for dim in array_shape]
         index_grids = np.meshgrid(*index_vecs, indexing="ij")
-        indeces_flat = [index_grid.flatten(order=array_order) for index_grid in index_grids]
+        indices_flat = [index_grid.flatten(order=array_order) for index_grid in index_grids]
 
         expand_history[existing_field._name] = {
             "shape": array_shape,
@@ -386,8 +386,8 @@ def _expand_array_fields(existing_fields):
             "fields": {},
         }
 
-        for i, indeces in enumerate(zip(*indeces_flat)):
-            name = f"{existing_field._name}[{','.join(map(str,indeces))}]"
+        for i, indices in enumerate(zip(*indices_flat)):
+            name = f"{existing_field._name}[{','.join(map(str,indices))}]"
             if existing_field._bit_offset is None:
                 bit_offset = None
             else:
@@ -401,7 +401,7 @@ def _expand_array_fields(existing_fields):
                 byte_order=existing_field._byte_order,
             )
 
-            expand_history[existing_field._name]["fields"][name] = indeces
+            expand_history[existing_field._name]["fields"][name] = indices
             return_fields.append(return_field)
 
     return return_fields, expand_history
@@ -432,8 +432,8 @@ def _unexpand_field_arrays(field_arrays, expand_history):
         array_dtype = field_arrays[list(array_details["fields"].keys())[0]].dtype
         array = np.zeros(array_shape, dtype=array_dtype)
 
-        for element_name, indeces in array_details["fields"].items():
-            array.__setitem__((slice(None),) + indeces, field_arrays[element_name])
+        for element_name, indices in array_details["fields"].items():
+            array.__setitem__((slice(None),) + indices, field_arrays[element_name])
             del return_field_arrays[element_name]
 
         return_field_arrays[array_name] = array

--- a/ccsdspy/utils.py
+++ b/ccsdspy/utils.py
@@ -82,7 +82,7 @@ def iter_packet_bytes(file, include_primary_header=True):
 
 
 def split_packet_bytes(file, include_primary_header=True):
-    """Retreive a list of bytes objects corresponding to each packet in a file.
+    """Retrieve a list of bytes objects corresponding to each packet in a file.
 
     This function works with mixed files containing multiple APIDs, which may
     include both fixed length and variable length packets.

--- a/docs/dev-guide/index.rst
+++ b/docs/dev-guide/index.rst
@@ -76,14 +76,14 @@ Any classes, functions, or variables that are private should either:
 Utilities
 ---------
 
-Within this reposiotory, utility functions are placed in the `util.py` file.
+Within this repository, utility functions are placed in the `util.py` file.
 These functions can be private or public.
 If these might be useful for other modules are user-focused, they should be made public.
 
 
 Linting and Code Formatting
 ===========================
-We enforce a minimum level of code style with our continuous intergration testing.
+We enforce a minimum level of code style with our continuous integration testing.
 This project makes use of `black <https://github.com/psf/black>`__ to format all code.
 To run this yourself before submitting code just use the following command::
 

--- a/docs/user-guide/ccsds.rst
+++ b/docs/user-guide/ccsds.rst
@@ -62,7 +62,7 @@ The mandatory packet primary header consists of four fields contained within 6 o
      - For telemetry (or reporting), set to '0', for a command (or request), set to '1'
    * - Secondary header flag
      - 1
-     - identicates the presence or absence of a secondary header. Set to '1' if present.
+     - indicates the presence or absence of a secondary header. Set to '1' if present.
    * - Application process identifier or APID
      - 11
      - The APID provides a way to uniquely identify sending or receiving applications on a space vehicle.

--- a/docs/user-guide/converters.rst
+++ b/docs/user-guide/converters.rst
@@ -8,7 +8,7 @@ Post-processing transformations are done through the Converters API, exposed thr
 
 #. Polynomial Transformation (`~ccsdspy.converters.PolyConverter`)
 
-   This applies a polynomial function to each value, using user-defined coeffients.
+   This applies a polynomial function to each value, using user-defined coefficients.
    
 #. Linear Transformation (`~ccsdspy.converters.LinearConverter`)
 
@@ -24,7 +24,7 @@ Post-processing transformations are done through the Converters API, exposed thr
 
 #. Stringify Bytes Transformation (`~ccsdspy.converters.StringifyBytesConverter`)
 
-   This converts byte arrays or multi-byte numbers to strings in numeric representations such as binary, hexidecimal, or octal.
+   This converts byte arrays or multi-byte numbers to strings in numeric representations such as binary, hexadecimal, or octal.
    
 .. contents::
    :depth: 2
@@ -61,7 +61,7 @@ An example of using a built in transformation to parse time, apply a linear tran
         "SecondField",
 	"SecondField_Converted",
 	converters.EnumConverter({
-	    0: "DISBLED",
+	    0: "DISABLED",
 	    1: "ENABLED",
 	    2: "STANDBY"
 	})

--- a/docs/user-guide/utils.rst
+++ b/docs/user-guide/utils.rst
@@ -11,9 +11,9 @@ This package provides a number of utilities to work with CCSDS packets.
 
 Iterating through Packet Bytes
 ==============================
-During debugging it is often useful to break a stream of multiple packets into a list of byte sequences associated with each packet. That is, the i'th element of the list will be a `bytes` object assosciated with the i'th packet in the file.
+During debugging it is often useful to break a stream of multiple packets into a list of byte sequences associated with each packet. That is, the i'th element of the list will be a `bytes` object associated with the i'th packet in the file.
 
-This can be done with the `utils.split_packet_bytes()` (returns a list) and `utils.iter_packet_bytes()` (returns a generator) functions. These functions have an optional keyword arugment `include_primary_header=True` which determines whether the primary header is included in the byte sequence returned. By default, it is included.
+This can be done with the `utils.split_packet_bytes()` (returns a list) and `utils.iter_packet_bytes()` (returns a generator) functions. These functions have an optional keyword argument `include_primary_header=True` which determines whether the primary header is included in the byte sequence returned. By default, it is included.
 
 This function works with mixed files containing multiple APIDs, which may include both fixed length and variable length packets.
 


### PR DESCRIPTION
Fixed a missing paren in PacketField.__repr__().

While I was at it, fixed some obviously misspelled words.  Weird thing is that the following "words" keep reappearing in cleanly-built html, even though they don't appear anywhere in the source files:

converteed
indeces
packats
replacment
Retreive
suports
