### PR TITLE
Add support for reset_file_obj 

### DIFF
--- a/ccsdspy/packet_types.py
+++ b/ccsdspy/packet_types.py
@@ -179,7 +179,7 @@ class FixedLength(_BasePacket):
             self._converters,
             "fixed_length",
             include_primary_header=True,
-            reset_file_obj=reset_file_obj
+            reset_file_obj=reset_file_obj,
         )
 
         # inspect the primary header and issue warning if appropriate
@@ -308,7 +308,7 @@ class VariableLength(_BasePacket):
             self._converters,
             "variable_length",
             include_primary_header=True,
-            reset_file_obj=reset_file_obj
+            reset_file_obj=reset_file_obj,
         )
 
         # inspect the primary header and issue warning if appropriate
@@ -607,7 +607,9 @@ def _get_fields_csv_file(csv_file):
     return fields
 
 
-def _load(file, fields, converters, decoder_name, include_primary_header=False, reset_file_obj=False):
+def _load(
+    file, fields, converters, decoder_name, include_primary_header=False, reset_file_obj=False
+):
     """Decode a file-like object containing a sequence of these packets.
 
     Parameters
@@ -665,7 +667,7 @@ def _load(file, fields, converters, decoder_name, include_primary_header=False, 
     field_arrays = _apply_post_byte_reoderings(field_arrays, orig_fields)
     field_arrays = _apply_converters(field_arrays, converters)
 
-    if hasattr(file, 'read') and reset_file_obj:
+    if hasattr(file, "read") and reset_file_obj:
         file.seek(pos)
     return field_arrays
 

--- a/ccsdspy/packet_types.py
+++ b/ccsdspy/packet_types.py
@@ -156,7 +156,7 @@ class FixedLength(_BasePacket):
         reset_file_obj : bool
            If True, leave the file object, when it is file buffer, where it was before load is called.
            Otherwise, (default), leave the file stream pos after the read packets.
-           Does not apply when file is a file location.
+           Does not apply when file is a string.
 
         Returns
         -------
@@ -282,7 +282,7 @@ class VariableLength(_BasePacket):
         reset_file_obj : bool
            If True, leave the file object, when it is file buffer, where it was before load is called.
            Otherwise, (default), leave the file stream pos after the read packets.
-           Does not apply when file is a file location.
+           Does not apply when file is a string.
 
         Returns
         -------
@@ -628,7 +628,7 @@ def _load(
     reset_file_obj : bool
            If True, leave the file object, when it is a file buffer, where it was before _load is called.
            Otherwise, (default), leave the file stream pos after the read packets.
-           Does not apply when file is a file location.
+           Does not apply when file is a string.
 
     Returns
     -------
@@ -641,7 +641,7 @@ def _load(
       the decoder_name is not one of the allowed values
     """
     if hasattr(file, "read"):
-        pos = file.tell()
+        file_pos = file.tell()
         file_bytes = np.frombuffer(file.read(), "u1")
     else:
         file_bytes = np.fromfile(file, "u1")
@@ -668,7 +668,7 @@ def _load(
     field_arrays = _apply_converters(field_arrays, converters)
 
     if hasattr(file, "read") and reset_file_obj:
-        file.seek(pos)
+        file.seek(file_pos)
     return field_arrays
 
 

--- a/ccsdspy/tests/test_byte_order.py
+++ b/ccsdspy/tests/test_byte_order.py
@@ -6,6 +6,7 @@ The test data covers all XTCE orderings requested in
 See also:
   ccsdspy/tests/data/byte_order/byte_order_packets.py
 """
+
 import glob
 import itertools
 import os

--- a/ccsdspy/tests/test_packet_types.py
+++ b/ccsdspy/tests/test_packet_types.py
@@ -21,7 +21,9 @@ csv_file_4col_with_array = os.path.join(packet_def_dir, "simple_csv_4col_with_ar
 csv_file_3col_with_array = os.path.join(packet_def_dir, "simple_csv_3col_with_array.csv")
 
 hs_packet_dir = os.path.join(dir_path, "data", "hs")
-random_binary_file = os.path.join(hs_packet_dir, "apid001", "SSAT1_2015-180-00-00-00_2015-180-01-59-58_1_1_sim.tlm")
+random_binary_file = os.path.join(
+    hs_packet_dir, "apid001", "SSAT1_2015-180-00-00-00_2015-180-01-59-58_1_1_sim.tlm"
+)
 random_packet_def = os.path.join(hs_packet_dir, "apid001", "defs.csv")
 
 
@@ -241,5 +243,3 @@ def test_load_without_moving_file_buffer_pos():
         pos = fp.tell()
         pkts.load(fp, reset_file_obj=True)
         assert pos == fp.tell()
-
-

--- a/ccsdspy/tests/test_packet_types.py
+++ b/ccsdspy/tests/test_packet_types.py
@@ -238,6 +238,7 @@ def test_variable_length_rejects_bit_offset():
 
 
 def test_load_without_moving_file_buffer_pos():
+    """Tests that load(..., reset_file_obj=True) works as intended."""
     pkts = FixedLength.from_file(random_packet_def)
     with open(random_binary_file, "rb") as fp:
         pos = fp.tell()

--- a/ccsdspy/tests/test_packet_types.py
+++ b/ccsdspy/tests/test_packet_types.py
@@ -20,6 +20,10 @@ csv_file_3col = os.path.join(packet_def_dir, "simple_csv_3col.csv")
 csv_file_4col_with_array = os.path.join(packet_def_dir, "simple_csv_4col_with_array.csv")
 csv_file_3col_with_array = os.path.join(packet_def_dir, "simple_csv_3col_with_array.csv")
 
+hs_packet_dir = os.path.join(dir_path, "data", "hs")
+random_binary_file = os.path.join(hs_packet_dir, "apid001", "SSAT1_2015-180-00-00-00_2015-180-01-59-58_1_1_sim.tlm")
+random_packet_def = os.path.join(hs_packet_dir, "apid001", "defs.csv")
+
 
 def test_FixedLength_initializer_copies_field_list():
     """Tests that the FixedLengthPacket initializer stores a copy of the
@@ -229,3 +233,13 @@ def test_variable_length_rejects_bit_offset():
                 ),
             ]
         )
+
+
+def test_load_without_moving_file_buffer_pos():
+    pkts = FixedLength.from_file(random_packet_def)
+    with open(random_binary_file, "rb") as fp:
+        pos = fp.tell()
+        pkts.load(fp, reset_file_obj=True)
+        assert pos == fp.tell()
+
+


### PR DESCRIPTION
So to be able to recall the .load of the method of the Packet Types multiple time on the same file buffer, as needed when one need to parse once the packet at a coarse level to decide what the finer packet structure is and the parse them again.

Fixes https://github.com/CCSDSPy/ccsdspy/issues/111
