### PR TITLE
Accept CCSDS header fields as converter inputs

### DIFF
--- a/ccsdspy/converters.py
+++ b/ccsdspy/converters.py
@@ -381,5 +381,3 @@ class StringifyBytesConverter(Converter):
         converted = np.array(converted, dtype=object)
 
         return converted
-
-

--- a/ccsdspy/converters.py
+++ b/ccsdspy/converters.py
@@ -381,3 +381,5 @@ class StringifyBytesConverter(Converter):
         converted = np.array(converted, dtype=object)
 
         return converted
+
+

--- a/ccsdspy/packet_types.py
+++ b/ccsdspy/packet_types.py
@@ -99,7 +99,13 @@ class _BasePacket:
 
         # Check that each of the input field names exists in the packet, and report
         # the missing fields if not
-        fields_in_packet_set = {field._name for field in self._fields}
+        # Collect valid names of fields, which include primary header fields as well
+        # as fields defined in the packet.
+        fields_in_packet_set = set()
+
+        for field in _prepend_primary_header_fields(self._fields):
+            fields_in_packet_set.add(field._name)
+
         input_field_names_set = set(input_field_names)
         all_fields_present = input_field_names_set <= fields_in_packet_set  # subset
 


### PR DESCRIPTION
This is a small step toward adding converter which calculate and compare the CRC of the packets with the CRC transmitted at the end of the packets.

I wrote a prototype for it in the Europa-Clipper application which uses ccsdspy, but I am not happy with it yet to propose it in the CCSDSpy repository.