### PR TITLE
Update Validation Ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__.
 
+Version 1.4.1 - 2025-03-14
+============================
+  * Updates the `ccsdspy.utils.validate()` function so that packets are split by APID before primary headers data is parsed. This change allows for more accurate validation of the primary headers and APIDs.
+  * This removes potentially misleading warnings from `read_primary_headers` for having multiple apids, having missing or out of order sequence counts.
+
 Version 1.4.0 - 2025-03-05
 ============================
   * Enhanced Docstrings to call out `Raises` and `Warns` 

--- a/ccsdspy/tests/test_utils.py
+++ b/ccsdspy/tests/test_utils.py
@@ -195,7 +195,7 @@ def test_validate_valid_apids():
     assert all("UserWarning: Found multiple AP IDs" not in warning for warning in result)
 
 
-def test_validatino_no_warnings():
+def test_validation_no_warnings():
     # Test with a Valid Test File
     num_packets = 3
     packet = create_simple_ccsds_packet(num_packets)  # noqa: F841

--- a/ccsdspy/tests/test_utils.py
+++ b/ccsdspy/tests/test_utils.py
@@ -151,9 +151,9 @@ def test_validate():
     valid_tlm_path = os.path.join(data_path, "CYGNSS_F7_L0_2022_086_10_15_V01_F__first101pkts.tlm")
     result = utils.validate(valid_tlm_path)
     assert len(result) == 3
-    assert any("UserWarning: Missing packets found" in warning for warning in result)
-    assert any("UserWarning: Sequence count are out of order." in warning for warning in result)
-    assert any("UserWarning: Found multiple AP IDs" in warning for warning in result)
+    assert all("UserWarning: Missing packets found" in warning for warning in result)
+    assert all("UserWarning: Sequence count are out of order." not in warning for warning in result)
+    assert all("UserWarning: Found multiple AP IDs" not in warning for warning in result)
 
     # Test with a file that has missing bytes
     with open(valid_tlm_path, "rb") as fh:

--- a/ccsdspy/utils.py
+++ b/ccsdspy/utils.py
@@ -284,11 +284,13 @@ def validate(file, valid_apids=None):
         warnings.simplefilter("always")  # Capture all warnings, even if repeated
 
         try:
-            # Check primary header consistency (sequence counts, APIDs)
-            read_primary_headers(file)
-
             # Check file integrity (truncation, extra bytes)
-            split_by_apid(file, valid_apids=valid_apids)
+            stream_by_apid = split_by_apid(file, valid_apids=valid_apids)
+
+            primary_headers_by_apid = {}
+            for apid in stream_by_apid:
+                # Check primary header consistency (sequence counts, APIDs)
+                primary_headers_by_apid[apid] = read_primary_headers(stream_by_apid[apid])
         except Exception as e:
             # Capture any exceptions as warnings
             warning_details.append(f"Exception: {str(e)}")


### PR DESCRIPTION
  * Updates the `ccsdspy.utils.validate()` function so that packets are split by APID before primary headers data is parsed. This change allows for more accurate validation of the primary headers and APIDs.
  * This removes potentially misleading warnings from `read_primary_headers` for having multiple apids, having missing or out of order sequence counts.

resolves #135 