### PR TITLE
Bump testing / package versions to 3.13

### DIFF
--- a/.github/workflows/ccsdspy-ci.yml
+++ b/.github/workflows/ccsdspy-ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.13]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__.
 
+
+Version 1.4.3 - 2025-11-06
+============================
+  * Add explicit support up to Python 3.13.
+
 Version 1.4.2 - 2025-06-08
 ============================
   * Fixed bug in `pkt.load()` where `IndexError` would be thrown when <6 bytes of garbage at ened of file (`Issue #139 <https://github.com/CCSDSPy/ccsdspy/issues/139>`_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",	
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Per discussions in #143 this increases the CI versions tested and the package versions in pyproject.toml to  Python 3.13