### PR TITLE
Increase required version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,11 @@ authors = [
   { name = "Steven Christe", email = "steven.d.christe@nasa.gov" },
 ]
 license = { file = "LICENSE.rst" }
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 keywords = ["python", "nasa", "ccsds", "space packet protocol"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This patch drops support for Python <3.10 for release v2.0, per discussion in ticket #150