### PR TITLE
Use APID metadata to warn if superflous APIDs found

### DIFF
--- a/ccsdspy/packet_types.py
+++ b/ccsdspy/packet_types.py
@@ -240,7 +240,7 @@ class FixedLength(_BasePacket):
         )
 
         # inspect the primary header and issue warning if appropriate
-        _inspect_primary_header_fields(packet_arrays)
+        _inspect_primary_header_fields(packet_arrays, self._apid)
 
         if not include_primary_header:
             _delete_primary_header_fields(packet_arrays)
@@ -376,7 +376,7 @@ class VariableLength(_BasePacket):
         )
 
         # inspect the primary header and issue warning if appropriate
-        _inspect_primary_header_fields(packet_arrays)
+        _inspect_primary_header_fields(packet_arrays, self._apid)
 
         if not include_primary_header:
             _delete_primary_header_fields(packet_arrays)
@@ -384,7 +384,7 @@ class VariableLength(_BasePacket):
         return packet_arrays
 
 
-def _inspect_primary_header_fields(packet_arrays):
+def _inspect_primary_header_fields(packet_arrays, specified_apid=None):
     """Inspects the primary header fields.
 
     Checks for the following issues
@@ -397,15 +397,20 @@ def _inspect_primary_header_fields(packet_arrays):
     packet_arrays
         dictionary mapping field names to NumPy arrays, with key order matching
         the order fields in the packet. Modified in place
+    specified_apid 
+        integer or None if not specified. Used to check APID of packets is as
+        expected.
 
     Warns
     -----
-    UserWarning
+    logging warning
         If the ccsds sequence count is not in order
-    UserWarning
+    logging warning
         If the ccsds sequence count is missing packets
-    UserWarning
+    logging warning
         If there are more than one APID
+    logging warning
+       If APID is specified in packet metadata but APIDs read don't match
     """
     seq_counts = packet_arrays["CCSDS_SEQUENCE_COUNT"]
     start, end = seq_counts[0], seq_counts[-1]
@@ -416,9 +421,13 @@ def _inspect_primary_header_fields(packet_arrays):
     if not np.all(seq_counts == np.sort(seq_counts)):
         log.warning("Sequence count are out of order.")
 
-    individual_ap_ids = set(packet_arrays["CCSDS_APID"])
-    if len(individual_ap_ids) != 1:
-        log.warning(f"Found multiple AP IDs {individual_ap_ids}.")
+    individual_apids = np.unique(packet_arrays["CCSDS_APID"]).astype(int).tolist()
+
+    if len(individual_apids) != 1:
+        log.warning(f"Found multiple APIDs {individual_apids}.")
+
+    if specified_apid is not None and individual_apids[0] != specified_apid:
+        log.warning(f"Unexpected APID(s) {individual_apids}; Expected {specified_apid}")
 
     return None
 

--- a/ccsdspy/tests/test_primary_header.py
+++ b/ccsdspy/tests/test_primary_header.py
@@ -210,6 +210,24 @@ def test_check_primary_header_contents_sameapid(caplog):
     with log.log_to_list() as log_list:
         _inspect_primary_header_fields(packet_data)
     assert log_list[0].levelname == "WARNING"
-    assert log_list[0].message.startswith("Found multiple AP IDs")
-    assert "48.0" in log_list[0].message
-    assert "58.0" in log_list[0].message
+    assert log_list[0].message.startswith("Found multiple APIDs")
+    assert "48" in log_list[0].message
+    assert "58" in log_list[0].message
+
+
+def test_check_primary_header_contents_wrong_apid(caplog):
+    """Check that all apids are the same."""
+    num_packets = 10000
+    packet_data = {
+        "CCSDS_SEQUENCE_COUNT": np.arange(1, num_packets),
+        "CCSDS_APID": 48 * np.ones(num_packets),
+    }
+    packet_data["CCSDS_APID"][100:200] = 58
+    with log.log_to_list() as log_list:
+        _inspect_primary_header_fields(packet_data, 999)
+    assert log_list[0].levelname == "WARNING"
+    assert log_list[0].message.startswith("Found multiple APIDs")
+    assert log_list[1].message.startswith("Unexpected APID(s)")
+    assert "48" in log_list[0].message
+    assert "58" in log_list[0].message
+    assert "999" in log_list[1].message


### PR DESCRIPTION
This adds a logging warning if an APID is specified in the packet metadata but packets of other APIDs are found when parsing